### PR TITLE
[WIP] Enables yarn workspaces

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Opla.ai Backend",
-  "main": "index.js",
+  "main": "dist/index.js",
   "author": "Mik BRY <mik@opla.co>",
   "license": "GPL-2.0+",
   "scripts": {
@@ -33,7 +33,7 @@
     "inquirer": "^5.1.0",
     "node-fetch": "^2.1.2",
     "opennlx": "0.6.1",
-    "zoapp-backend": "0.23.5",
+    "zoapp-backend": "0.23.6",
     "zoapp-core": "0.12.3",
     "zoauth-server": "0.9.2"
   },

--- a/front/src/client/index.jsx
+++ b/front/src/client/index.jsx
@@ -6,7 +6,7 @@
  */
 import Opla from "OplaLibs/opla";
 
-import "zoapp-front/compressed.css";
+import "zoapp-front/dist/compressed.css";
 
 import "../public/css/animate.min.css";
 import "../public/css/messenger.css";

--- a/front/src/shared/actions/api.js
+++ b/front/src/shared/actions/api.js
@@ -10,7 +10,7 @@ import {
   FETCH_SUCCESS,
   SUBSCRIBE,
   UNSUBSCRIBE,
-} from "zoapp-front/actions/constants";
+} from "zoapp-front/src/shared/actions/constants";
 
 import {
   API_CREATEBOT,

--- a/front/src/shared/components/templatesList.jsx
+++ b/front/src/shared/components/templatesList.jsx
@@ -8,7 +8,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Grid, Inner, Cell } from "zrmc";
 import makeClassName from "classnames";
-import FileInput from "zoapp-front/components/fileInput";
+import FileInput from "zoapp-front/src/shared/components/fileInput";
 import { robotsColors } from "../utils/robotsColors";
 
 const TemplatesList = ({

--- a/front/src/shared/containers/about.jsx
+++ b/front/src/shared/containers/about.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { appSetTitle } from "zoapp-front/actions/app";
+import { appSetTitle } from "zoapp-front/src/shared/actions/app";
 
 const aboutStyle = {
   fontSize: "18px",

--- a/front/src/shared/containers/agentManager.jsx
+++ b/front/src/shared/containers/agentManager.jsx
@@ -8,9 +8,9 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import Zrmc, { Grid, Inner, Cell } from "zrmc";
-import Loading from "zoapp-front/components/loading";
-import SignInForm from "zoapp-front/containers/signInForm";
-import { appSetTitle } from "zoapp-front/actions/app";
+import Loading from "zoapp-front/src/shared/components/loading";
+import SignInForm from "zoapp-front/src/shared/containers/signInForm";
+import { appSetTitle } from "zoapp-front/src/shared/actions/app";
 
 import {
   apiGetIntentsRequest,

--- a/front/src/shared/containers/createAssistant.jsx
+++ b/front/src/shared/containers/createAssistant.jsx
@@ -9,8 +9,8 @@ import PropTypes from "prop-types";
 import Zrmc, { Select, MenuItem, Button, TextField } from "zrmc";
 import { connect } from "react-redux";
 import { withRouter } from "react-router";
-import ProcessingDialog from "zoapp-front/containers/processingDialog";
-import { appSetTitle, setMessage } from "zoapp-front/actions/app";
+import ProcessingDialog from "zoapp-front/src/shared/containers/processingDialog";
+import { appSetTitle, setMessage } from "zoapp-front/src/shared/actions/app";
 
 import TemplatesList from "../components/templatesList";
 import {

--- a/front/src/shared/containers/dashboard.jsx
+++ b/front/src/shared/containers/dashboard.jsx
@@ -8,9 +8,9 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Grid, Inner, Cell, Icon } from "zrmc";
-import Loading from "zoapp-front/components/loading";
+import Loading from "zoapp-front/src/shared/components/loading";
 
-import { appSetTitle } from "zoapp-front/actions/app";
+import { appSetTitle } from "zoapp-front/src/shared/actions/app";
 import { apiGetMetricsRequest } from "../actions/api";
 
 const metricStyle = {

--- a/front/src/shared/containers/publishContainer.jsx
+++ b/front/src/shared/containers/publishContainer.jsx
@@ -8,7 +8,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { apiGetBotParametersRequest } from "OplaLibs/actions/api";
-import { appSetTitle } from "zoapp-front/actions/app";
+import { appSetTitle } from "zoapp-front/src/shared/actions/app";
 // eslint-disable-next-line import/no-unresolved
 import config from "../../../config/default.json";
 

--- a/front/src/shared/containers/servicesContainer.jsx
+++ b/front/src/shared/containers/servicesContainer.jsx
@@ -9,8 +9,8 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import Zrmc, { Cell } from "zrmc";
 import { ListComponent } from "zoapp-ui";
-import ServicesList from "zoapp-front/components/servicesList";
-import displayWebServiceEditor from "zoapp-front/components/displayWebServiceEditor";
+import ServicesList from "zoapp-front/src/shared/components/servicesList";
+import displayWebServiceEditor from "zoapp-front/src/shared/components/displayWebServiceEditor";
 
 import displayProviderEditor from "../components/displayProviderEditor";
 import {

--- a/front/src/shared/opla.js
+++ b/front/src/shared/opla.js
@@ -6,22 +6,22 @@
  */
 /* eslint react/display-name: 0 */
 import React from "react";
-import Front from "zoapp-front/front";
+import Front from "zoapp-front/src/shared/front";
 import About from "OplaContainers/about";
 import Home from "OplaContainers/home";
 import CreateAssistant from "OplaContainers/createAssistant";
-import AdminManager from "zoapp-front/containers/adminManager";
+import AdminManager from "zoapp-front/src/shared/containers/adminManager";
 import AgentManager from "OplaContainers/agentManager";
 import PublishContainer from "OplaContainers/publishContainer";
 import configureStore from "OplaLibs/store";
-import DrawerFooter from "zoapp-front/containers/drawerFooter";
+import DrawerFooter from "zoapp-front/src/shared/containers/drawerFooter";
 import Zrmc, { Inner, Cell, Button } from "zrmc";
 import PublishDialog from "OplaContainers/dialogs/publishDialog";
 import { defaultTemplates, defaultLanguages } from "OplaLibs/reducers/app";
 import Extension from "OplaContainers/admin/extensions";
 import GeneralAdmin from "OplaContainers/admin/generalAdmin";
-import Users from "zoapp-front/containers/admin/users";
-import Advanced from "zoapp-front/containers/admin/advanced";
+import Users from "zoapp-front/src/shared/containers/admin/users";
+import Advanced from "zoapp-front/src/shared/containers/admin/advanced";
 // eslint-disable-next-line import/no-unresolved
 import config from "../../config/default.json";
 

--- a/front/src/shared/reducers/app/index.js
+++ b/front/src/shared/reducers/app/index.js
@@ -4,12 +4,12 @@
  * This source code is licensed under the GPL v2.0+ license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import createReducer from "zoapp-front/reducers/createReducer";
+import createReducer from "zoapp-front/src/shared/reducers/createReducer";
 
 import {
   initialState as zoappInitialState,
   handlers as zoappHandlers,
-} from "zoapp-front/reducers/app";
+} from "zoapp-front/src/shared/reducers/app";
 
 import {
   API_ADMIN,
@@ -17,7 +17,7 @@ import {
   FETCH_FAILURE,
   FETCH_REQUEST,
   FETCH_SUCCESS,
-} from "zoapp-front/actions/constants";
+} from "zoapp-front/src/shared/actions/constants";
 
 import {
   API_CREATEBOT,

--- a/front/src/shared/reducers/app/intents.js
+++ b/front/src/shared/reducers/app/intents.js
@@ -8,7 +8,7 @@ import {
   FETCH_FAILURE,
   FETCH_REQUEST,
   FETCH_SUCCESS,
-} from "zoapp-front/actions/constants";
+} from "zoapp-front/src/shared/actions/constants";
 
 import {
   /* API Section */

--- a/front/src/shared/reducers/index.js
+++ b/front/src/shared/reducers/index.js
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { combineReducers } from "redux";
-import auth from "zoapp-front/reducers/auth";
-import initialize from "zoapp-front/reducers/initialize";
-import user from "zoapp-front/reducers/user";
+import auth from "zoapp-front/src/shared/reducers/auth";
+import initialize from "zoapp-front/src/shared/reducers/initialize";
+import user from "zoapp-front/src/shared/reducers/user";
 
 import app from "./app";
 import message from "./message";

--- a/front/src/shared/reducers/message.js
+++ b/front/src/shared/reducers/message.js
@@ -4,15 +4,15 @@
  * This source code is licensed under the GPL v2.0+ license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import createReducer from "zoapp-front/reducers/createReducer";
+import createReducer from "zoapp-front/src/shared/reducers/createReducer";
 
 import {
   initialState as zoappInitialState,
   handlers as zoappHandlers,
   addErrorToState,
-} from "zoapp-front/reducers/message";
+} from "zoapp-front/src/shared/reducers/message";
 
-import { FETCH_FAILURE } from "zoapp-front/actions/constants";
+import { FETCH_FAILURE } from "zoapp-front/src/shared/actions/constants";
 
 import {
   API_CREATEBOT,

--- a/front/src/shared/reducers/metrics.js
+++ b/front/src/shared/reducers/metrics.js
@@ -4,12 +4,12 @@
  * This source code is licensed under the GPL v2.0+ license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import createReducer from "zoapp-front/reducers/createReducer";
+import createReducer from "zoapp-front/src/shared/reducers/createReducer";
 import {
   FETCH_FAILURE,
   FETCH_REQUEST,
   FETCH_SUCCESS,
-} from "zoapp-front/actions/constants";
+} from "zoapp-front/src/shared/actions/constants";
 
 import { API_GETMETRICS } from "../actions/constants";
 

--- a/front/src/shared/sagas/api.js
+++ b/front/src/shared/sagas/api.js
@@ -12,9 +12,9 @@ import {
   FETCH_SUCCESS,
   SUBSCRIBE,
   UNSUBSCRIBE,
-} from "zoapp-front/actions/constants";
-import zoappApi from "zoapp-front/sagas/api";
-import { getWebService, createSocketService } from "zoapp-front/services";
+} from "zoapp-front/src/shared/actions/constants";
+import zoappApi from "zoapp-front/src/shared/sagas/api";
+import { getWebService, createSocketService } from "zoapp-front/src/shared/services";
 import {
   API_CREATEBOT,
   API_DELETEINTENT,

--- a/front/src/shared/sagas/index.js
+++ b/front/src/shared/sagas/index.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { takeEvery } from "redux-saga";
-import auth from "zoapp-front/sagas/auth";
+import auth from "zoapp-front/src/shared/sagas/auth";
 
 import api from "./api";
 

--- a/front/src/shared/store.js
+++ b/front/src/shared/store.js
@@ -6,7 +6,7 @@
  */
 import { createStore, applyMiddleware, compose } from "redux";
 import createSagaMiddleware from "redux-saga";
-import signoutMiddleware from "zoapp-front/middleware/signoutMiddleware";
+import signoutMiddleware from "zoapp-front/src/shared/middleware/signoutMiddleware";
 import reducers from "./reducers";
 import rootSaga from "./sagas";
 

--- a/front/tests/shared/reducers/app/app.test.js
+++ b/front/tests/shared/reducers/app/app.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 import * as apiActions from "shared/actions/api";
-import * as authActions from "zoapp-front/actions/auth";
-import { appSetTitle } from "zoapp-front/actions/app";
+import * as authActions from "zoapp-front/src/shared/actions/auth";
+import { appSetTitle } from "zoapp-front/src/shared/actions/app";
 import reducer, {
   initialState,
   defaultTemplates,

--- a/front/tests/shared/reducers/message.test.js
+++ b/front/tests/shared/reducers/message.test.js
@@ -1,4 +1,4 @@
-import * as actions from "zoapp-front/actions/message";
+import * as actions from "zoapp-front/src/shared/actions/message";
 import reducer, { initialState } from "shared/reducers/message";
 import {
   API_CREATEBOT,
@@ -17,7 +17,7 @@ import {
   API_SENDINTENT,
   API_SETMIDDLEWARE,
 } from "shared/actions/constants";
-import { FETCH_FAILURE } from "zoapp-front/actions/constants";
+import { FETCH_FAILURE } from "zoapp-front/src/shared/actions/constants";
 
 const errorTypes = [
   API_GETMIDDLEWARES + FETCH_FAILURE,


### PR DESCRIPTION
- removes `cd dist/ && yarn publish` hack
- removes aliases (that are not recognised by vscode, and sometimes longer than their path equivalent (e.g. `OplaLibs` vs. `./`).
- switches from `zoapp-front/` to `zoapp-front/src/shared/` in order to have easy hot reloading on a file change in the library (without needing to recompile `zoapp-front`, babel gets executed anyways by webpack in opla-front).