### PR TITLE
add required db affinity to non-preemptible nodes

### DIFF
--- a/backend/charts/opla-backend/requirements.yaml
+++ b/backend/charts/opla-backend/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: mariadb
-  version: 4.2.5
+  version: 4.4.0
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: mariadb.enabled

--- a/backend/charts/opla-backend/templates/1-opla-embedded-db.yaml
+++ b/backend/charts/opla-backend/templates/1-opla-embedded-db.yaml
@@ -53,4 +53,8 @@ spec:
           value: {{ .Values.db.user }}
         - name: MYSQL_PASSWORD
           value: {{ .Values.db.password }}
+      {{- with .Values.embedded_db.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
 {{- end}}

--- a/backend/charts/opla-backend/values.preprod.yaml
+++ b/backend/charts/opla-backend/values.preprod.yaml
@@ -17,3 +17,11 @@ db_mode: persistent
 
 mariadb:
   enabled: true
+  master:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: cloud.google.com/gke-preemptible
+              operator: DoesNotExist

--- a/backend/charts/opla-backend/values.prod.yaml
+++ b/backend/charts/opla-backend/values.prod.yaml
@@ -24,3 +24,10 @@ mariadb:
   master:
     persistence:
       storageClass: snapshot-promoter
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: cloud.google.com/gke-preemptible
+              operator: DoesNotExist

--- a/backend/charts/opla-backend/values.qa.yaml
+++ b/backend/charts/opla-backend/values.qa.yaml
@@ -12,3 +12,12 @@ db:
 tls: true
 
 namespace: ${K8S_NAMESPACE}
+
+embedded_db:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: cloud.google.com/gke-preemptible
+            operator: DoesNotExist


### PR DESCRIPTION
This prevents the mysql database to be scheduled on preemptible nodes.
It should help fixing the following :
- the fact that <24h after a deployment, qa becomes unusable because the non-persistant DB gets deleted
- `preprod` and `prod` should no longer have downtime (even short ones) when preemptible nodes get deleted. `mariadb` master will now be scheduled on a non-preemptible node. (see my PR in helm https://github.com/helm/charts/pull/7202 for further info)