### PR TITLE
Typo on docker install script

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -104,7 +104,7 @@ _() {
 		if [ -z "$NON_INTERACTIVE" ]; then
 			question=$1
 			echo ""
-			echo -n $question" (Y/n)\\n"
+			echo -n $question" (Y/n) "
 			read answer
 			if [ -z $answer ]; then
 				echo "--> Yes"


### PR DESCRIPTION
Just a very quick fix on docker installation script, a char sequence was not correctly handled (\\n)

