### PR TITLE
Add management_endpoint var in prod values

### DIFF
--- a/backend/charts/opla-backend/values.prod.yaml
+++ b/backend/charts/opla-backend/values.prod.yaml
@@ -2,12 +2,12 @@ image:
   tag: ${COMMIT_SHA}
 
 api:
+  management_endpoint: "" # replace by "/management" to activate.
   domain: ${K8S_NAMESPACE}.${DOMAIN_SUFFIX}
   extraDomains:
     - console.${DOMAIN_SUFFIX}
     - console.opla.ai
-
-db: 
+db:
   auth:
     clientId: ${CLIENT_ID}
     secret: ${CLIENT_SECRET}


### PR DESCRIPTION
Co-authored-by: arnaud-moncel <arnaud.moncel43@gmail.com>

# Description

Should fix the CircleCI issue on (2584)[https://circleci.com/gh/Opla/opla/2584] - Quite ugly though. 
`management_endpoint` is set to "" instead of false, but this should at least avoid the error.

# How Has This Been Tested?

Passing CircleCI `prod_deploy` will be the test


