### PR TITLE
Should fix console deploy

### DIFF
--- a/backend/charts/opla-backend/templates/3-ingress.yaml
+++ b/backend/charts/opla-backend/templates/3-ingress.yaml
@@ -13,7 +13,7 @@ spec:
     {{- define "backend.paths" }}
     http:
       paths:
-      {{- with $.Values.api.management_endpoint }}
+      {{- with .Values.api.management_endpoint }}
       - path: /api/v1{{.}}
         backend:
           serviceName: none
@@ -37,7 +37,7 @@ spec:
 {{- include "backend.paths" . }}
   {{- range .Values.api.extraDomains }}
   - host: {{ . }}
-{{- include "backend.paths" . }}
+{{- include "backend.paths" $ }}
   {{- end }}
 
   {{- if eq .Values.tls true }}

--- a/backend/charts/opla-backend/values.prod.yaml
+++ b/backend/charts/opla-backend/values.prod.yaml
@@ -2,7 +2,6 @@ image:
   tag: ${COMMIT_SHA}
 
 api:
-  management_endpoint: "" # replace by "/management" to activate.
   domain: ${K8S_NAMESPACE}.${DOMAIN_SUFFIX}
   extraDomains:
     - console.${DOMAIN_SUFFIX}


### PR DESCRIPTION
# Description

Actually pretty strange ...
`{{- with $.Values.api.management_endpoint }}`
 wasn't accessing real $ scope ...

Choosed to now pass $ context to `{{- include "backend.paths" $ }}`, and access global scope directly via 

## Type of change

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

It was tested via [helm template](https://github.com/technosophos/helm-template) plugin. Will be truly tested when merged in master, and CI redeploy console app

**Test Configuration**:
* Yarn/npm/nodejs version: not rel.
* OS version: not rel.
* Chrome version: not rel.
* Helm version: `Client: &version.Version{SemVer:"v2.12.2", GitCommit:"7d2b0c73d734f6586ed222a567c5d103fed435be", GitTreeState:"clean"}`


# Checklist:

Not rel.