### PR TITLE
Removed management_endpoint when undefined or false

### DIFF
--- a/backend/charts/opla-backend/templates/2-opla-backend.yaml
+++ b/backend/charts/opla-backend/templates/2-opla-backend.yaml
@@ -96,5 +96,7 @@ spec:
             value: {{.Values.api.domain}}/auth
           - name: ZOAPP__GLOBAL__PUBLIC_URL
             value: {{.Values.api.domain}}/api
+            {{- if .Values.api.management_endpoint }}
           - name: ZOAPP__GLOBAL__MANAGEMENT_ENDPOINT
             value: {{.Values.api.management_endpoint}}
+            {{- end}}


### PR DESCRIPTION
# Description

After scope error, fix management_endpoint not handle as a boolean, since `container.env.value` should always be a string

## Type of change

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, infra, ...)

# How Has This Been Tested?

Not rel.

# Checklist:

Not rel.