### PR TITLE
Moduled bot index to allow create more five bot

### DIFF
--- a/front/src/shared/components/assistantCard.jsx
+++ b/front/src/shared/components/assistantCard.jsx
@@ -19,27 +19,27 @@ const AssistantCard = ({
   selectedIndex,
 }) => {
   const className =
-    index > -1 && selectedIndex === index
-      ? "selectedListItem"
-      : "selectableListItem";
+    selectedIndex === index ? "selectedListItem" : "selectableListItem";
+
+  const moduledIndex = index % robotsColors.length;
+
   let icon;
   if (item.icon) {
     icon = <Icon className="opla_assistant_card-img">{item.icon}</Icon>;
   } else if (index > -1) {
     icon = (
       <img
-        src={`./images/robots/robot-${index}.svg`}
+        src={`./images/robots/robot-${moduledIndex}.svg`}
         className="opla_assistant_card-img"
         alt={item.name}
       />
     );
   }
-  const color =
-    index > -1
-      ? {
-          backgroundColor: robotsColors[`robot-${index}`].mainColor,
-        }
-      : {};
+
+  let color;
+  if (index > -1) {
+    color = robotsColors[moduledIndex].mainColor;
+  }
 
   return (
     <Cell
@@ -63,7 +63,10 @@ const AssistantCard = ({
                 <FileInput onLoad={onImport} accept={acceptImport} />
               </form>
             ) : (
-              <div className="opla_assistant_card-background" style={color}>
+              <div
+                className="opla_assistant_card-background"
+                style={{ backgroundColor: color }}
+              >
                 <div className="opla_assistant_card-imgMask">{icon}</div>
               </div>
             )}

--- a/front/src/shared/utils/robotsColors.js
+++ b/front/src/shared/utils/robotsColors.js
@@ -1,23 +1,23 @@
 /* eslint import/prefer-default-export: 0 */
-export const robotsColors = {
-  "robot-0": {
+export const robotsColors = [
+  {
     mainColor: "#4cdbc4",
     name: "robot-0",
   },
-  "robot-1": {
+  {
     mainColor: "#54c0eb",
     name: "robot-1",
   },
-  "robot-2": {
+  {
     mainColor: "#84DBFF",
     name: "robot-2",
   },
-  "robot-3": {
+  {
     mainColor: "#324A5E",
     name: "robot-3",
   },
-  "robot-4": {
+  {
     mainColor: "#90DFAA",
     name: "robot-4",
   },
-};
+];


### PR DESCRIPTION
# Description

Add modulo on index bot to allow display more five bot.

**Fixes #164**

## Type of change

- [X] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Yarn test & lint have been launched.

**Test Configuration**:
* Yarn/npm/nodejs version: v1.12.3/v6.5.0/v8.10.0
* OS version: macOS 10.14.2
* Chrome version: Google Chrome 71.0.3578.98 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
