### PR TITLE
Should fix automatic scroll when reloading or when new message arrive

### DIFF
--- a/front/src/shared/components/messengerBox/index.js
+++ b/front/src/shared/components/messengerBox/index.js
@@ -59,10 +59,10 @@ class MessengerBox extends Component {
 
   componentDidUpdate() {
     const node = this.messengerContent;
-    this.shouldScrollBottom =
-      node.scrollTop + node.offsetHeight === node.scrollHeight;
-    if (this.shouldScrollBottom) {
-      node.scrollTop = node.scrollHeight;
+    if (node.scrollTop + node.offsetHeight !== node.scrollHeight) {
+      const { scrollHeight, clientHeight } = node;
+      const maxScrollTop = scrollHeight - clientHeight;
+      node.scrollTop = maxScrollTop > 0 ? maxScrollTop : 0;
     }
   }
 


### PR DESCRIPTION
# Description
Repaired automatic scroll when new message arrived or page reload

**Fixes #31**

## Type of change

Please delete options that are not relevant.

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

No added tests. Manual tests were done in order to validate that this feature actually works

**Test Configuration**:
* Yarn/npm/nodejs version: v1.13.0/v6.5.0/v11.9.0
* OS version: macOS 10.14.3
* Chrome version: Google Chrome 72.0.3626.109 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
