### PR TITLE
Fix publish container for get bot params with not auth user

### DIFF
--- a/front/src/shared/containers/publishContainer.jsx
+++ b/front/src/shared/containers/publishContainer.jsx
@@ -28,9 +28,8 @@ class PublishContainer extends Component {
   render() {
     const { botParameters } = this.props;
 
-    if (botParameters === null || botParameters === undefined) {
-      return null;
-    } else if (
+    if (
+      !botParameters ||
       !botParameters.application ||
       !botParameters.application.id ||
       !botParameters.application.secret ||
@@ -54,7 +53,6 @@ class PublishContainer extends Component {
     }
 
     const url = this.urlBuilder.createUrl("/");
-
     const parameters = {
       botId: botParameters.botId,
       appId: botParameters.application.id,
@@ -68,7 +66,6 @@ class PublishContainer extends Component {
     };
 
     const params = encodeURI(JSON.stringify(parameters));
-
     return (
       <iframe frameBorder="0" src={`/bot.html?config=${params}`} width="100%" />
     );

--- a/front/src/shared/opla.js
+++ b/front/src/shared/opla.js
@@ -72,7 +72,7 @@ const appProps = {
       ),
       name: "Factory",
       path: "/factory",
-      access: "auth",
+      access: "all",
       panels: ["Dashboard", "Builder", "Analytics", "Extensions"],
       toolbox: [
         {

--- a/front/src/shared/sagas/bot.js
+++ b/front/src/shared/sagas/bot.js
@@ -75,7 +75,10 @@ const bot = [
     API_BOTS_PARAMETERS + FETCH_REQUEST,
     function* f({ name }) {
       try {
-        const response = yield getWebService().get(`bots/params/${name}`);
+        const response = yield getWebService().get(
+          `bots/params/${name}`,
+          false,
+        );
         yield put(apiGetBotParametersSucess(response));
       } catch (error) {
         yield put(apiGetBotParametersFailure(error));


### PR DESCRIPTION
# Description

Fix bug when you get publish page with no auth user.

## Type of change

- [X] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Yarn test & lint have been launched.

**Test Configuration**:
* Yarn/npm/nodejs version: v1.13.0/v5.6.0/v8.10.0
* OS version: macOS 10.14.3
* Chrome version: Google Chrome 72.0.3626.109 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
