### PR TITLE
Change unsaved item color to be more visible. Made .item_notsaved bigger

### DIFF
--- a/front/src/stylesheets/_all.scss
+++ b/front/src/stylesheets/_all.scss
@@ -280,12 +280,12 @@ html {
   }
  
   .item_notsaved {
-   width: 2px;
-   height: 36px;
-   position: fixed;
-   left: 0px;
-   background: #b71c1c;
-   margin-top: -4px;
+    width: 5px;
+    height: 36px;
+    position: fixed;
+    left: 0px;
+    background: #e23f3f;
+    margin-top: -4px;
   }
  
   .gray_dot {


### PR DESCRIPTION
# Description

Not so much here. Just changed 2 properties in CSS 

**Fixes #184**

## Type of change

Please delete options that are not relevant.

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Except for 2 css lines, nothing was changed 

**Test Configuration**:
* Yarn/npm/nodejs version: v1.13.0/v6.5.0/v11.9.0
* OS version: macOS 10.14.3
* Chrome version: Google Chrome 72.0.3626.109 

# Checklist:

Please remove lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code