### PR TITLE
Fix new intent having default input/output

### DIFF
--- a/front/src/shared/containers/factory.jsx
+++ b/front/src/shared/containers/factory.jsx
@@ -73,7 +73,7 @@ class Factory extends Component {
       input = [intentName];
     }
     let { output } = data;
-    if (!output) {
+    if (!output && this.props.intents.length < 1) {
       // TODO create a better output
       let i = input[0];
       const il = i.toLowerCase();
@@ -81,6 +81,9 @@ class Factory extends Component {
         i = "I don't understand.";
       }
       output = [i];
+    } else {
+      input = [];
+      output = [];
     }
     const intent = {
       input,


### PR DESCRIPTION
# Description

Fix new intent having default input/output.
Now only the first intent will have content, all the other one should be empty

**Fixes #34**

## Type of change

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

**Test Configuration**:
* Yarn/npm/nodejs version: v1.13.0/v6.5.0/v11.9.0
* OS version: macOS 10.14.3
* Chrome version: Google Chrome 72.0.3626.119 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

