### PR TITLE
Fix undefined URL caused when calling json WS without valid URL

### DIFF
--- a/backend/src/middlewares/openNLX.js
+++ b/backend/src/middlewares/openNLX.js
@@ -319,9 +319,8 @@ class OpenNLXMiddleware {
       if (ws) {
         // WIP
         const post = { action, parameters };
-        const url = `${ws.url}${ws.path}?class=${className}&secret=${
-          ws.secret
-        }`;
+        const path = ws.path || "";
+        const url = `${ws.url}${path}?class=${className}&secret=${ws.secret}`;
         // console.log("url=", url);
         const response = await fetch(url, {
           method: "post",


### PR DESCRIPTION
# Description

Fix a bug on missing `path` variable when calling JSON WS

## Type of change

Please delete options that are not relevant.

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Ran existing unit tests for backend 

**Test Configuration**:
* Yarn/npm/nodejs version: v1.13.0/v5.6.0/v8.10.0
* OS version: macOS 10.14.3
* Chrome version: Google Chrome 72.0.3626.121
# Checklist:

Please remove lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

