### PR TITLE
Disable autocomplete on playground input

### DIFF
--- a/front/src/shared/components/messengerBox/messengerBoxInput.jsx
+++ b/front/src/shared/components/messengerBox/messengerBoxInput.jsx
@@ -43,6 +43,7 @@ class MessengerBoxInput extends Component {
           style={{ width: "30vw", height: "18px", margin: "8px" }}
           noFloatingLabel
           maxLength="280"
+          autoComplete="off"
           ref={this.textFieldRef}
           onKeyUp={(e) => {
             if (e.key === "Enter") {


### PR DESCRIPTION
# Description

Just add `autocomplete="off"` on playground input

**Fixes #228**

## Type of change

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

No test provided

**Test Configuration**:
* Yarn/npm/nodejs version: v1.13.0/v6.7.0/v11.10.1
* OS version: macOS 10.14.3
* Chrome version: Google Chrome 73.0.3683.75 

# Checklist:

Please remove lines that are not relevant

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

