### PR TITLE
Change green color in action_output class

### DIFF
--- a/front/src/stylesheets/_theming.scss
+++ b/front/src/stylesheets/_theming.scss
@@ -467,7 +467,7 @@ i.zui-subheader-right:hover {
 }
 
 .action_output {
-  border: 1px solid #4b830d;
+  border: 1px solid #22e182;
 }
 
 .action_variable {


### PR DESCRIPTION
# Description

Change green color in action_output class in view to increase contrast with action_variable.

**Fixes #197**

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Simply display _output code_ and _code_ in output text editor : 
![test](https://user-images.githubusercontent.com/22832527/54814478-20c08400-4c90-11e9-9a0a-613e4b48049f.png)


**Test Configuration**:
* Yarn/npm/nodejs version: 1.12.3/6.5.0/8.10.0
* OS version: macOs 10.14.3
* Chrome version: 72.0.3626.121

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
