### PR TITLE
Fix JSON WS not called

### DIFF
--- a/backend/src/middlewares/openNLX.js
+++ b/backend/src/middlewares/openNLX.js
@@ -344,12 +344,14 @@ class OpenNLXMiddleware {
 
     const wss = await middlewares.list({ origin: botId, type: "WebService" });
     if (wss && wss.length > 0) {
-      const ws = wss[0];
+      const ws = wss.find((m) => m.classes.includes(className));
       if (ws) {
         // WIP
         const post = { action, parameters };
         const path = ws.path || "";
-        const url = `${ws.url}${path}?class=${className}&secret=${ws.secret}`;
+        const url = `${ws.url}${path}?class=${ws.classes[0]}&secret=${
+          ws.secret
+        }`;
         // console.log("url=", url);
         const response = await fetch(url, {
           method: "post",
@@ -397,7 +399,7 @@ class OpenNLXMiddleware {
     /* eslint-disable no-restricted-syntax */
     /* eslint-disable no-await-in-loop */
     for (const bot of bots) {
-      logger.info("bot=", bot);
+      // logger.info("bot=", bot);
       this.openNLX.createAgent(bot);
       // Add intents to openNLX
       let intents = await botsController.getIntents(bot.id);

--- a/backend/src/middlewares/openNLX.js
+++ b/backend/src/middlewares/openNLX.js
@@ -256,8 +256,9 @@ class OpenNLXMiddleware {
       // handle intents events
       if (data.action === "createBot") {
         // create bot
-        const { bot } = data;
+        const { bot, botId } = data;
         this.openNLX.createAgent(bot);
+        this.openNLX.setCallablesObserver(botId, this.callables.bind(this));
       } else if (data.action === "updateBot") {
         // WIP update bot
         const { bot } = data;
@@ -396,7 +397,7 @@ class OpenNLXMiddleware {
     /* eslint-disable no-restricted-syntax */
     /* eslint-disable no-await-in-loop */
     for (const bot of bots) {
-      // logger.info("bot=", bot);
+      logger.info("bot=", bot);
       this.openNLX.createAgent(bot);
       // Add intents to openNLX
       let intents = await botsController.getIntents(bot.id);


### PR DESCRIPTION
# Description

Should fix JSON WS not called by setting callable manually on "createBot" dispatch
Instead of always getting the first middleware, I also check for `classes` to contains specified `className` in output.

**Fixes #244**

## Type of change

- [x] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

Manually tested by importing an existing bot with existing WS call.

**Test Configuration**:
* Yarn/npm/nodejs version: v/v/
* OS version: macOS 10.14.3
* Chrome version: Google Chrome 73.0.3683.86 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
