### PR TITLE
Upgrade opennlx to fix intent ref

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -32,7 +32,7 @@
     "fs-extra": "^5.0.0",
     "inquirer": "^5.1.0",
     "node-fetch": "^2.1.2",
-    "opennlx": "0.8.5",
+    "opennlx": "0.8.6",
     "zoapp-backend": "0.24.10",
     "zoapp-core": "0.13.1",
     "zoauth-server": "0.10.11"

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -4168,10 +4168,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-opennlx@0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/opennlx/-/opennlx-0.8.5.tgz#3adc02b0030f25e1ec9fbc390009fa5789833a8e"
-  integrity sha512-QCQi3+iDgwJoQiqmThmiu0d1Gw6rtYaaWbm4AWPHymrYamo97gJrTP0n0zOie3Wu7b2LA1fQlKDcwSpTj/4RYQ==
+opennlx@0.8.6:
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/opennlx/-/opennlx-0.8.6.tgz#cd524c364b23b4a21633558653d0f4a57f141dc0"
+  integrity sha512-Ad7FlIkqoDcJMWlgZ7QAtUaGtY6o0QkPqngKZYZSybN/t7IdB85ru54zqJtIvLxlVvdDO7jootYEfcD6LDIWgg==
 
 openurl@1.1.1:
   version "1.1.1"


### PR DESCRIPTION
# Description

Upgrade opennlx to fix intent ref.

## Type of change

- [X] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

**Test Configuration**:
* Yarn/npm/nodejs version: v1.15.2/v6.9.0/v8.10.0
* OS version: macOS 10.14.4
* Chrome version: Google Chrome 73.0.3683.103 
