### PR TITLE
Fix reset context on reset webchat reset conversation

### DIFF
--- a/backend/src/controllers/messenger.js
+++ b/backend/src/controllers/messenger.js
@@ -153,10 +153,10 @@ export default class extends Controller {
     const conversation = await this.getConversation(null, conversationId);
     if (conversation) {
       await this.model.deleteConversationMessages(conversationId);
-      return this.dispatch(this.className, {
-        action: "deleteConversationMessages",
-        conversationId,
+      await this.dispatch(this.className, {
         origin: conversation.origin,
+        conversationId,
+        action: "resetConversation",
       });
     }
     return null;


### PR DESCRIPTION
# Description

Fix reset context on reset webchat reset conversation

## Type of change

- [X] Other (non-breaking change which doesn't match an issue, Non-code related, ...)

# How Has This Been Tested?

**Test Configuration**:
* Yarn/npm/nodejs version: v1.16.0/v6.4.1/v10.15.3
* OS version: macOS 10.14.5
* Chrome version: Google Chrome 75.0.3770.100 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
